### PR TITLE
Task.15-2の修正

### DIFF
--- a/app/models/article.rb
+++ b/app/models/article.rb
@@ -3,6 +3,6 @@ class Article < ApplicationRecord
   validates :content, presence: true, uniqueness: {case_sensitive: false}
 
   belongs_to :user
-  has_many :tag_article
-  has_many :tag, through: :tag_article
+  has_many :tag_articles, dependent: :destroy
+  has_many :tags, through: :tag_articles
 end

--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -1,6 +1,6 @@
 class Tag < ApplicationRecord
   validates :name, presence: true, uniqueness: {case_sensitive: false}
 
-  has_many :article
-  has_many :article, through: :tag_article
+  has_many :tag_articles, dependent: :destroy
+  has_many :articles, through: :tag_article
 end


### PR DESCRIPTION
tagモデルとarticleモデルの関連付けについて、以下2点を修正
・多対多を表すためにhas_manyの関連付けを単数形から複数形に修正
・中間テーブルtag_articleとの関連付けが抜けていたため追加